### PR TITLE
fix error: g13d-service Default-Start contains no runlevels, aborting.

### DIFF
--- a/src/g13d-service
+++ b/src/g13d-service
@@ -1,4 +1,12 @@
 #!/bin/bash
+### BEGIN INIT INFO
+# Provides:          g13d-service
+# Required-Start:    $all
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: handle g13d
+### END INIT INFO
 G13D_HOME="/usr/lib/g13d"
 PID=""
 


### PR DESCRIPTION
added some headers to the script so that ubuntu 20.10 doesn't complain about missing runlevels